### PR TITLE
Improve performance for tagging Closure Library

### DIFF
--- a/src/com/anychart/gjstags/ctags/CTag.java
+++ b/src/com/anychart/gjstags/ctags/CTag.java
@@ -15,6 +15,9 @@
  */
 package com.anychart.gjstags.ctags;
 
+import java.io.Writer;
+import java.io.IOException;
+
 /**
  * @author Aleksandr Batsuev (alex@batsuev.com)
  */
@@ -42,6 +45,15 @@ public class CTag {
 
     public String getCTagString() {
         return this.getName() + "\t" + this.getFile() + "\t" + this.getAddress() + this.getMeta() + "\n";
+
+    public void writeCTagString(Writer writer) throws IOException {
+        writer.write(this.getName());
+        writer.write('\t');
+        writer.write(this.getFile());
+        writer.write('\t');
+        writer.write(this.getAddress());
+        writer.write(this.getMeta());
+        writer.write('\n');
     }
 
     public static CTag fromString(String line) {

--- a/src/com/anychart/gjstags/ctags/CTagsFile.java
+++ b/src/com/anychart/gjstags/ctags/CTagsFile.java
@@ -18,6 +18,7 @@ package com.anychart.gjstags.ctags;
 import com.anychart.gjstags.CommandLineRunner;
 
 import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -59,12 +60,11 @@ public class CTagsFile {
     }
 
     public void write(String fileName) throws IOException {
-        FileWriter writer = new FileWriter(fileName);
-        String tagsString = HEADER;
+        BufferedWriter writer = new BufferedWriter(new FileWriter(fileName));
+        writer.write(HEADER);
         for (CTag tag : this.entries) {
-            tagsString += tag.getCTagString();
+            tag.writeCTagString(writer);
         }
-        writer.write(tagsString);
         writer.close();
     }
 


### PR DESCRIPTION
On large libraries like the Closure Library, gjstags was spinning for a
long time creating the world's largest string. Using buffered output
makes the entire tagging of the Closure Library take about 30 seconds.
